### PR TITLE
Improving the communication pattern

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,16 +9,16 @@ target_link_libraries(scalapack2scalapack PRIVATE grid2grid options)
 ################
 if (MPI_FOUND)
     add_test(NAME square-blocks-divisible COMMAND ${MPIEXEC}
-        ${MPIEXEC_NUMPROC_FLAG} 4 --oversubscribe scalapack2scalapack -m 10 -n 10 -ibm 2 -ibn 2 -fbm 5 -fbn 5 -pm 2 -pn 2)
+        ${MPIEXEC_NUMPROC_FLAG} 4 ./scalapack2scalapack -m 10 -n 10 -ibm 2 -ibn 2 -fbm 5 -fbn 5 -pm 2 -pn 2)
 
     add_test(NAME square-blocks-non-divisible COMMAND ${MPIEXEC}
-        ${MPIEXEC_NUMPROC_FLAG} 4 --oversubscribe scalapack2scalapack -m 10 -n 10 -ibm 2 -ibn 3 -fbm 3 -fbn 5 -pm 2 -pn 2)
+        ${MPIEXEC_NUMPROC_FLAG} 4 ./scalapack2scalapack -m 10 -n 10 -ibm 2 -ibn 3 -fbm 3 -fbn 5 -pm 2 -pn 2)
 
     add_test(NAME non_square-blocks-non-divisible COMMAND ${MPIEXEC}
-        ${MPIEXEC_NUMPROC_FLAG} 4 --oversubscribe scalapack2scalapack -m 10 -n 12 -ibm 2 -ibn 3 -fbm 2 -fbn 6 -pm 2 -pn 2)
+        ${MPIEXEC_NUMPROC_FLAG} 4 ./scalapack2scalapack -m 10 -n 12 -ibm 2 -ibn 3 -fbm 2 -fbn 6 -pm 2 -pn 2)
 
     add_test(NAME non-square-blocks-non-divisible COMMAND ${MPIEXEC}
-        ${MPIEXEC_NUMPROC_FLAG} 4 --oversubscribe scalapack2scalapack -m 10 -n 12 -ibm 2 -ibn 3 -fbm 3 -fbn 5 -pm 2 -pn 2)
+        ${MPIEXEC_NUMPROC_FLAG} 4 ./scalapack2scalapack -m 10 -n 12 -ibm 2 -ibn 3 -fbm 3 -fbn 5 -pm 2 -pn 2)
 endif ()
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,6 +25,12 @@ if (MPI_FOUND)
 
     add_test(NAME non-square-blocks-non-divisible COMMAND ${MPIEXEC}
         ${MPIEXEC_NUMPROC_FLAG} 4 ./scalapack2scalapack -m 10 -n 12 -ibm 2 -ibn 3 -fbm 3 -fbn 5 -pm 2 -pn 2)
+
+    add_test(NAME scalapack_submatrix COMMAND ${MPIEXEC}
+        ${MPIEXEC_NUMPROC_FLAG} 1 ./scalapack_submatrix)
+
+    add_test(NAME parallel_scalapack_submatrix COMMAND ${MPIEXEC}
+        ${MPIEXEC_NUMPROC_FLAG} 4 ./parallel_scalapack_submatrix)
 endif ()
 
 

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -28,6 +28,22 @@ bool message<T>::operator<(const message<T> &other) const {
            (get_rank() == other.get_rank() && b < other.get_block());
 }
 
+template <typename T>
+void communication_data<T>::partition_messages() {
+    if (mpi_messages.size() == 0) 
+        return;
+
+    int pivot = -1; 
+    for (int i = 0; i < mpi_messages.size(); ++i) {
+        int rank = mpi_messages[i].get_rank();
+        if (pivot != rank) {
+            pivot = rank;
+            package_ticks.push_back(i);
+        }
+    }
+    package_ticks.push_back(mpi_messages.size());
+}
+
 // ************************
 //   COMMUNICATION DATA
 // ************************
@@ -44,6 +60,8 @@ communication_data<T>::communication_data(std::vector<message<T>> &messages,
 
     int offset = 0;
 
+    int prev_rank = -1;
+
     for (unsigned i = 0; i < messages.size(); ++i) {
         const auto &m = messages[i];
         int target_rank = m.get_rank();
@@ -58,6 +76,7 @@ communication_data<T>::communication_data(std::vector<message<T>> &messages,
             offset += b.total_size();
             counts[target_rank] += b.total_size();
             total_size += b.total_size();
+            prev_rank = target_rank;
         } else {
             local_blocks.push_back(b);
         }
@@ -74,6 +93,8 @@ communication_data<T>::communication_data(std::vector<message<T>> &messages,
             ++n_packed_messages;
         }
     }
+
+    partition_messages();
 }
 
 template <typename T>
@@ -111,6 +132,18 @@ void communication_data<T>::copy_to_buffer() {
         int target_rank = m.get_rank();
         // std::cout << "rank = " << rank << std::endl;
         copy_block_to_buffer(b, data() + offset_per_message[i]);
+    }
+}
+
+template <typename T>
+void communication_data<T>::copy_from_buffer(int idx) {
+    assert(idx >= 0 && idx+1 < package_ticks.size());
+#pragma omp parallel for
+    for (unsigned i = package_ticks[idx]; i < package_ticks[idx+1]; ++i) {
+        const auto &m = mpi_messages[i];
+        block<T> b = m.get_block();
+        int target_rank = m.get_rank();
+        copy_block_from_buffer(data() + offset_per_message[i], b);
     }
 }
 

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -81,8 +81,8 @@ void copy_block_to_buffer(block<T> b, T *dest_ptr) {
         // because block b will be transposed
         // in the buffer without any stride
         // (we make the buffer packed)
-        int dest_stride = b.n_cols();
-        memory::copy_and_transpose(b, dest_ptr, b.n_cols());
+        int dest_stride = b.n_rows();
+        memory::copy_and_transpose(b, dest_ptr, dest_stride);
         // b.stride = b.n_cols();
     }
 }

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -1,4 +1,5 @@
 #include <grid2grid/communication_data.hpp>
+#include <grid2grid/profiler.hpp>
 
 #include <complex>
 
@@ -52,6 +53,7 @@ communication_data<T>::communication_data(std::vector<message<T>> &messages,
                                           int rank, int n_ranks)
     : n_ranks(n_ranks)
     , my_rank(rank) {
+    PE(transform_commdata);
     // std::cout << "constructor of communciation data invoked" << std::endl;
     dspls = std::vector<int>(n_ranks);
     counts = std::vector<int>(n_ranks);
@@ -95,6 +97,7 @@ communication_data<T>::communication_data(std::vector<message<T>> &messages,
     }
 
     partition_messages();
+    PL();
 }
 
 template <typename T>

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -67,6 +67,13 @@ communication_data<T>::communication_data(std::vector<message<T>> &messages,
     for (unsigned i = 1; i < (unsigned)n_ranks; ++i) {
         dspls[i] = dspls[i - 1] + counts[i - 1];
     }
+
+    n_packed_messages = 0;
+    for (unsigned i = 0; i < (unsigned) n_ranks; ++i) {
+        if (counts[i]) {
+            ++n_packed_messages;
+        }
+    }
 }
 
 template <typename T>

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -137,7 +137,7 @@ void copy_block_to_block(block<T>& src, block<T>& dest) {
 template <typename T>
 void copy_local_blocks(std::vector<block<T>>& from, std::vector<block<T>>& to) {
     assert(from.size() == to.size());
-#pragma omp parallel for
+// #pragma omp parallel for
     for (unsigned i = 0u; i < from.size(); ++i) {
         auto& block_src = from[i];
         auto& block_dest = to[i];

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -32,39 +32,41 @@ bool message<T>::operator<(const message<T> &other) const {
 //   COMMUNICATION DATA
 // ************************
 template <typename T>
-communication_data<T>::communication_data(std::vector<message<T>> &&msgs,
-                                          int n_ranks)
-    : messages(std::forward<std::vector<message<T>>>(msgs))
-    , n_ranks(n_ranks) {
-
+communication_data<T>::communication_data(std::vector<message<T>> &messages,
+                                          int rank, int n_ranks)
+    : n_ranks(n_ranks)
+    , my_rank(rank) {
     // std::cout << "constructor of communciation data invoked" << std::endl;
     dspls = std::vector<int>(n_ranks);
     counts = std::vector<int>(n_ranks);
-    offset_per_message = std::vector<int>(messages.size());
+    mpi_messages.reserve(messages.size());
+    offset_per_message.reserve(messages.size());
 
     int offset = 0;
 
     for (unsigned i = 0; i < messages.size(); ++i) {
         const auto &m = messages[i];
-        int rank = m.get_rank();
+        int target_rank = m.get_rank();
         block<T> b = m.get_block();
-        offset_per_message[i] = offset;
-        offset += b.total_size();
-        // copy_block_to_buffer(b, buffer.begin() + offset);
         assert(b.non_empty());
-        counts[rank] += b.total_size();
-        total_size += b.total_size();
 
-        // std::cout << "rank = " << rank << std::endl;
-        // std::cout << "counts[rank] = " << counts[rank] << std::endl;
+        // if the message should be communicated to 
+        // a different rank
+        if (target_rank != my_rank) {
+            mpi_messages.push_back(m);
+            offset_per_message.push_back(offset);
+            offset += b.total_size();
+            counts[target_rank] += b.total_size();
+            total_size += b.total_size();
+        } else {
+            local_blocks.push_back(b);
+        }
     }
+
     buffer = std::unique_ptr<T[]>(new T[total_size]);
-    // buffer = std::vector<double, cosma::mpi_allocator<double>>(total_size);
     for (unsigned i = 1; i < (unsigned)n_ranks; ++i) {
         dspls[i] = dspls[i - 1] + counts[i - 1];
-        // std::cout << "dpsls[rank] = " << dspls[i] << std::endl;
     }
-    // std::cout << "total_size = " << total_size << std::endl;
 }
 
 template <typename T>
@@ -74,7 +76,13 @@ void copy_block_to_buffer(block<T> b, T *dest_ptr) {
     if (!b.transpose_on_copy)
         memory::copy2D(b.size(), b.data, b.stride, dest_ptr, b.n_rows());
     else {
-        memory::copy_and_transpose(b, dest_ptr);
+        // stride in the destination
+        // is the number of columns
+        // because block b will be transposed
+        // in the buffer without any stride
+        // (we make the buffer packed)
+        int dest_stride = b.n_cols();
+        memory::copy_and_transpose(b, dest_ptr, b.n_cols());
         // b.stride = b.n_cols();
     }
 }
@@ -90,10 +98,10 @@ void communication_data<T>::copy_to_buffer() {
     // std::cout << "commuication data.copy_to_buffer()" << std::endl;
 
 #pragma omp parallel for
-    for (unsigned i = 0; i < messages.size(); ++i) {
-        const auto &m = messages[i];
+    for (unsigned i = 0; i < mpi_messages.size(); ++i) {
+        const auto &m = mpi_messages[i];
         block<T> b = m.get_block();
-        // int rank = m.get_rank();
+        int target_rank = m.get_rank();
         // std::cout << "rank = " << rank << std::endl;
         copy_block_to_buffer(b, data() + offset_per_message[i]);
     }
@@ -101,14 +109,12 @@ void communication_data<T>::copy_to_buffer() {
 
 template <typename T>
 void communication_data<T>::copy_from_buffer() {
-    int offset = 0;
 #pragma omp parallel for
-    for (unsigned i = 0; i < messages.size(); ++i) {
-        const auto &m = messages[i];
+    for (unsigned i = 0; i < mpi_messages.size(); ++i) {
+        const auto &m = mpi_messages[i];
         block<T> b = m.get_block();
-        // int rank = m.get_rank();
+        int target_rank = m.get_rank();
         copy_block_from_buffer(data() + offset_per_message[i], b);
-        offset += b.total_size();
     }
 }
 
@@ -117,14 +123,63 @@ T *communication_data<T>::data() {
     return buffer.get();
 }
 
+template <typename T>
+void copy_block_to_block(block<T>& src, block<T>& dest) {
+    // std::cout << "copy buffer->block" << std::endl;
+    if (!src.transpose_on_copy) {
+        memory::copy2D(src.size(), src.data, src.stride, dest.data, dest.stride);
+    } else {
+        // transpose and conjugate if necessary while copying
+        memory::copy_and_transpose(src, dest.data, dest.stride);
+    }
+}
+
+template <typename T>
+void copy_local_blocks(std::vector<block<T>>& from, std::vector<block<T>>& to) {
+    assert(from.size() == to.size());
+#pragma omp parallel for
+    for (unsigned i = 0u; i < from.size(); ++i) {
+        auto& block_src = from[i];
+        auto& block_dest = to[i];
+        assert(block_src.non_empty());
+        assert(block_src.total_size() == block_dest.total_size());
+        // destination block cannot be transposed
+        assert(!block_dest.transpose_on_copy);
+
+        copy_block_to_block(block_src, block_dest);
+    }
+}
+
+// template instantiation for communication_data
 template class communication_data<double>;
 template class communication_data<std::complex<double>>;
 template class communication_data<float>;
 template class communication_data<std::complex<float>>;
 
+// template instantiation for message
 template class message<double>;
 template class message<std::complex<double>>;
 template class message<float>;
 template class message<std::complex<float>>;
+
+// template instantiation for copy_local_blocks
+template void
+copy_local_blocks(std::vector<block<double>>& from, std::vector<block<double>>& to);
+template void
+copy_local_blocks(std::vector<block<float>>& from, std::vector<block<float>>& to);
+template void
+copy_local_blocks(std::vector<block<std::complex<float>>>& from, std::vector<block<std::complex<float>>>& to);
+template void
+copy_local_blocks(std::vector<block<std::complex<double>>>& from, std::vector<block<std::complex<double>>>& to);
+
+// template instantiation for copy_block_to_block
+template void
+copy_block_to_block(block<double>& src, block<double>& dest);
+template void
+copy_block_to_block(block<float>& src, block<float>& dest);
+template void
+copy_block_to_block(block<std::complex<float>>& src, block<std::complex<float>>& dest);
+template void
+copy_block_to_block(block<std::complex<double>>& src, block<std::complex<double>>& dest);
 
 } // namespace grid2grid

--- a/src/grid2grid/communication_data.hpp
+++ b/src/grid2grid/communication_data.hpp
@@ -34,13 +34,19 @@ class communication_data {
     // std::vector<double, cosma::mpi_allocator<double>> buffer;
     std::vector<int> dspls;
     std::vector<int> counts;
-    std::vector<message<T>> messages;
+    // mpi_messages are the ones that have to be
+    // communicated to a different rank
+    std::vector<message<T>> mpi_messages;
+    // blocks which should be copied locally,
+    // and not through MPI
+    std::vector<block<T>> local_blocks;
     int n_ranks = 0;
     int total_size = 0;
+    int my_rank;
 
     communication_data() = default;
 
-    communication_data(std::vector<message<T>> &&msgs, int n_ranks);
+    communication_data(std::vector<message<T>> &msgs, int my_rank, int n_ranks);
 
     void copy_to_buffer();
 
@@ -51,4 +57,7 @@ class communication_data {
   private:
     std::vector<int> offset_per_message;
 };
+
+template <typename T>
+void copy_local_blocks(std::vector<block<T>>& from, std::vector<block<T>>& to);
 } // namespace grid2grid

--- a/src/grid2grid/communication_data.hpp
+++ b/src/grid2grid/communication_data.hpp
@@ -43,6 +43,7 @@ class communication_data {
     int n_ranks = 0;
     int total_size = 0;
     int my_rank;
+    int n_packed_messages = 0;
 
     communication_data() = default;
 

--- a/src/grid2grid/communication_data.hpp
+++ b/src/grid2grid/communication_data.hpp
@@ -51,11 +51,17 @@ class communication_data {
 
     void copy_to_buffer();
 
+    // copy all mpi_messages from buffer
     void copy_from_buffer();
+    // copy mpi_messages[idx] from buffer
+    void copy_from_buffer(int idx);
 
     T *data();
 
+    void partition_messages();
+
   private:
+    std::vector<int> package_ticks;
     std::vector<int> offset_per_message;
 };
 

--- a/src/grid2grid/memory_utils.hpp
+++ b/src/grid2grid/memory_utils.hpp
@@ -58,16 +58,13 @@ void copy2D(const std::pair<size_t, size_t> &block_dim,
 
 // copy from block to MPI send buffer
 template <typename T>
-void copy_and_transpose(const block<T> b, T* dest_ptr) {
+void copy_and_transpose(const block<T> b, T* dest_ptr, int dest_stride) {
     static_assert(std::is_trivially_copyable<T>(),
             "Element type must be trivially copyable!");
     assert(b.non_empty());
     // n_rows and n_cols before transposing
     int n_rows = b.n_cols();
     int n_cols = b.n_rows();
-    // n_rows and n_cols after transposing
-    int n_rows_t = n_cols;
-    int n_cols_t = n_rows;
 
     int block_dim = 32;
     int block_i;
@@ -86,7 +83,7 @@ void copy_and_transpose(const block<T> b, T* dest_ptr) {
                     // (j, i) in the send buffer, column-major
                     if (b.conjugate_on_copy)
                         el = conjugate(el);
-                    dest_ptr[i*n_rows_t + j] = el;
+                    dest_ptr[i*dest_stride + j] = el;
                 }
             }
         }

--- a/src/grid2grid/transform.cpp
+++ b/src/grid2grid/transform.cpp
@@ -307,42 +307,63 @@ get_scalapack_grid(scalapack::data_layout &layout, T *ptr, int rank) {
 }
 
 template <typename T>
+void exchange(communication_data<T>& send_data, communication_data<T>& recv_data, MPI_Comm comm) {
+    int send_count = 0;
+
+    int n_messages = send_data.n_packed_messages + recv_data.n_packed_messages;
+    MPI_Request reqs[n_messages];
+
+    int request_idx = 0;
+    // initiate all receives
+    for (unsigned i = 0u; i < recv_data.n_ranks; ++i) {
+        if (recv_data.counts[i]) {
+            MPI_Irecv(recv_data.data() + recv_data.dspls[i],
+                      recv_data.counts[i],
+                      mpi_type_wrapper<T>::type(),
+                      i, 0, comm,
+                      &reqs[request_idx]);
+            ++request_idx;
+        }
+    }
+
+    request_idx = 0;
+    // initiate all sends
+    for (unsigned i = 0u; i < send_data.n_ranks; ++i) {
+        if (send_data.counts[i]) {
+            MPI_Isend(send_data.data() + send_data.dspls[i], 
+                      send_data.counts[i],
+                      mpi_type_wrapper<T>::type(),
+                      i, 0, comm,
+                      &reqs[recv_data.n_packed_messages + request_idx]);
+            ++request_idx;
+        }
+    }
+
+    MPI_Waitall(n_messages, reqs, MPI_STATUSES_IGNORE);
+}
+
+template <typename T>
 void transform(grid_layout<T> &initial_layout,
                grid_layout<T> &final_layout,
                MPI_Comm comm) {
     int rank;
     MPI_Comm_rank(comm, &rank);
 
-    // MPI_Barrier(comm);
-    // auto total_start = std::chrono::steady_clock::now();
     communication_data<T> send_data =
         prepare_to_send(initial_layout, final_layout, rank);
-    // auto start = std::chrono::steady_clock::now();
-    // auto prepare_send =
-    // std::chrono::duration_cast<std::chrono::milliseconds>(start -
-    // total_start).count();
+
     communication_data<T> recv_data =
         prepare_to_recv(final_layout, initial_layout, rank);
 
-    // copy local data (that are on the same rank in both initial and final layout)
-    // this is independent of MPI and can be executed in parallel
-    // copy_local_blocks(send_data.local_blocks, recv_data.local_blocks);
-    std::thread local_copy(copy_local_blocks<T>, 
-                           std::ref(send_data.local_blocks),
-                           std::ref(recv_data.local_blocks));
-    // auto end = std::chrono::steady_clock::now();
-    // auto prepare_recv =
-    // std::chrono::duration_cast<std::chrono::milliseconds>(end -
-    // start).count();
+    // std::thread local_copy(copy_local_blocks<T>, 
+    //                        std::ref(send_data.local_blocks),
+    //                        std::ref(recv_data.local_blocks));
+
     // copy blocks to temporary send buffers
     // start = std::chrono::steady_clock::now();
     PE(transformation_pack);
     send_data.copy_to_buffer();
     PL();
-    // end = std::chrono::steady_clock::now();
-    // auto copy_to_buffer_duration =
-    // std::chrono::duration_cast<std::chrono::milliseconds>(end -
-    // start).count();
 #ifdef DEBUG
     std::cout << "send buffer content: " << std::endl;
     for (int i = 0; i < send_data.total_size; ++i) {
@@ -352,23 +373,25 @@ void transform(grid_layout<T> &initial_layout,
     }
     std::cout << std::endl;
 #endif
-    // start = std::chrono::steady_clock::now();
+
     // perform the communication
-    PE(transformation_all2all);
-    MPI_Alltoallv(send_data.data(),
-                  send_data.counts.data(),
-                  send_data.dspls.data(),
-                  mpi_type_wrapper<T>::type(),
-                  recv_data.data(),
-                  recv_data.counts.data(),
-                  recv_data.dspls.data(),
-                  mpi_type_wrapper<T>::type(),
-                  comm);
+    PE(transformation_exchange);
+    exchange(send_data, recv_data, comm);
+
+    // MPI_Alltoallv(send_data.data(),
+    //               send_data.counts.data(),
+    //               send_data.dspls.data(),
+    //               mpi_type_wrapper<T>::type(),
+    //               recv_data.data(),
+    //               recv_data.counts.data(),
+    //               recv_data.dspls.data(),
+    //               mpi_type_wrapper<T>::type(),
+    //               comm);
     PL();
-    // end = std::chrono::steady_clock::now();
-    // auto comm_duration =
-    // std::chrono::duration_cast<std::chrono::milliseconds>(end -
-    // start).count();
+
+    // copy local data (that are on the same rank in both initial and final layout)
+    // this is independent of MPI and can be executed in parallel
+    copy_local_blocks(send_data.local_blocks, recv_data.local_blocks);
 
 #ifdef DEBUG
     std::cout << "recv buffer content: " << std::endl;
@@ -379,29 +402,12 @@ void transform(grid_layout<T> &initial_layout,
     }
     std::cout << std::endl;
 #endif
-    // start = std::chrono::steady_clock::now();
     // copy blocks from a temporary buffer back to blocks
     PE(transformation_unpack);
     recv_data.copy_from_buffer();
     PL();
-    // end = std::chrono::steady_clock::now();
-    // auto copy_from_buffer_duration =
-    // std::chrono::duration_cast<std::chrono::milliseconds>(end -
-    // start).count();
 
-    // auto total_end = std::chrono::steady_clock::now();
-    // auto total_duration =
-    // std::chrono::duration_cast<std::chrono::milliseconds>(total_end -
-    // total_start).count(); if (rank == 0) {
-    //     std::cout << "prepare send: " << prepare_send << std::endl;
-    //     std::cout << "prepare recv: " << prepare_recv << std::endl;
-    //     std::cout << "copy: blocks -> buffer: " << copy_to_buffer_duration <<
-    //     std::endl; std::cout << "communication: : " << comm_duration <<
-    //     std::endl; std::cout << "copy: buffer -> blocks: " <<
-    //     copy_from_buffer_duration << std::endl; std::cout << "total: " <<
-    //     total_duration << std::endl;
-    // }
-    local_copy.join();
+    // local_copy.join();
 }
 
 template void transform<float>(grid_layout<float> &initial_layout,


### PR DESCRIPTION
This PR brings the following improvements:
- local blocks which belong to both initial and final layout are being directly copied from the initial layout to the final layout, without packing, unpacking and without going through MPI.
- MPI_Alltoallv is changed to multiple MPI_Isend and MPI_Irecv because the communication pattern is sparse most of the time.