### PR TITLE
Optimization/communication

### DIFF
--- a/src/grid2grid/CMakeLists.txt
+++ b/src/grid2grid/CMakeLists.txt
@@ -5,7 +5,9 @@ add_library(grid2grid STATIC block.cpp
                              communication_data.cpp
                              grid_cover.cpp
                              ranks_reordering.hpp
-                             transform.cpp)
+                             transform.cpp
+                             transformer.hpp
+                             )
 
 target_include_directories(grid2grid PUBLIC
   $<BUILD_INTERFACE:${grid2grid_SOURCE_DIR}/src>

--- a/src/grid2grid/CMakeLists.txt
+++ b/src/grid2grid/CMakeLists.txt
@@ -13,7 +13,14 @@ target_include_directories(grid2grid PUBLIC
   $<BUILD_INTERFACE:${grid2grid_SOURCE_DIR}/src>
   )
 
-target_link_libraries(grid2grid PUBLIC OpenMP::OpenMP_CXX MPI::MPI_CXX)
+find_package(blaze)
+if( blaze_FOUND )
+    message("BLAZE FOUND")
+    # add_library( blaze_target INTERFACE )
+    target_link_libraries( grid2grid PUBLIC blaze::blaze )
+endif()
+
+target_link_libraries(grid2grid PUBLIC OpenMP::OpenMP_CXX MPI::MPI_CXX blaze::blaze)
 
 if(GRID2GRID_WITH_PROFILING)
     target_link_libraries(grid2grid PRIVATE 

--- a/src/grid2grid/CMakeLists.txt
+++ b/src/grid2grid/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(grid2grid STATIC block.cpp
                              scalapack_layout.cpp
                              communication_data.cpp
                              grid_cover.cpp
+                             ranks_reordering.hpp
                              transform.cpp)
 
 target_include_directories(grid2grid PUBLIC

--- a/src/grid2grid/block.cpp
+++ b/src/grid2grid/block.cpp
@@ -191,6 +191,7 @@ block<T> block<T>::subblock(interval r_range, interval c_range) const {
     if (conjugate_on_copy)
         flag = 'C';
     b.transpose_or_conjugate(flag);
+    b.tag = tag;
     return b;
 }
 
@@ -205,9 +206,15 @@ bool block<T>::non_empty() const {
 
 template <typename T>
 bool block<T>::operator<(const block &other) const {
-    return cols_interval.start < other.cols_interval.start ||
-           (cols_interval.start == other.cols_interval.start &&
-            rows_interval.start < other.rows_interval.start);
+    return cols_interval < other.cols_interval ||
+           (cols_interval == other.cols_interval &&
+            rows_interval < other.rows_interval) ||
+           (cols_interval == other.cols_interval &&
+            rows_interval == other.rows_interval &&
+            tag < other.tag);
+    // return cols_interval.start < other.cols_interval.start ||
+    //        (cols_interval.start == other.cols_interval.start &&
+    //         rows_interval.start < other.rows_interval.start);
 }
 
 template <typename T>

--- a/src/grid2grid/block.hpp
+++ b/src/grid2grid/block.hpp
@@ -60,6 +60,9 @@ inline std::ostream &operator<<(std::ostream &os, const block_range &other) {
 // assumes column-major ordering inside block
 template <typename T>
 struct block {
+    // blocks from different matrices
+    // should have different tags
+    int tag = 0;
     // start and end index of the block
     interval rows_interval;
     interval cols_interval;

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -94,6 +94,7 @@ struct comm_volume {
             auto& e = vol.first;
             int w = vol.second;
             volume[e.sorted()] += w;
+            // volume[e] += w;
         }
         return *this;
     }
@@ -104,23 +105,38 @@ struct comm_volume {
             auto& e = vol.first;
             auto w = vol.second;
             sum_comm_vol[e.sorted()] += w;
+            // sum_comm_vol[e] += w;
         }
         for (const auto& vol : other.volume) {
             auto& e = vol.first;
             auto w = vol.second;
             sum_comm_vol[e.sorted()] += w;
+            // sum_comm_vol[e] += w;
         }
         return sum_comm_vol;
     }
 
-    int total_volume() {
-        int sum = 0;
+    size_t total_volume() {
+        size_t sum = 0;
         for (const auto& vol : volume) {
             auto& e = vol.first;
             int w = vol.second;
-            sum += w;
+            // if not a local communication, count it
+            if (e.src != e.dest) {
+                sum += w;
+            }
         }
         return sum;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const comm_volume &other) {
+        os << "Communication volume consists of the following:" << std::endl;
+        for (const auto& vol : other.volume) {
+            auto& e = vol.first;
+            int w = vol.second;
+            os << e.src << "->" << e.dest << ": " << w << std::endl;
+        }
+        return os;
     }
 };
 }

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -103,12 +103,12 @@ struct comm_volume {
         for (const auto& vol : volume) {
             auto& e = vol.first;
             auto w = vol.second;
-            sum_comm_vol[e.sorted] += w;
+            sum_comm_vol[e.sorted()] += w;
         }
         for (const auto& vol : other.volume) {
             auto& e = vol.first;
             auto w = vol.second;
-            sum_comm_vol[e.sorted] += w;
+            sum_comm_vol[e.sorted()] += w;
         }
         return sum_comm_vol;
     }

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -11,6 +11,11 @@ struct edge_t {
         src(src), dest(dest) {}
     // edge_t(edge_t& e): src(e.src), dest(e.dest) {}
 
+    edge_t sorted() const {
+        int u = std::min(src, dest);
+        int v = std::max(src, dest);
+        return edge_t{u, v};
+    }
     bool operator==(const edge_t& other) const {
         return src==other.src && dest==other.dest;
     }
@@ -88,7 +93,7 @@ struct comm_volume {
         for (const auto& vol : other.volume) {
             auto& e = vol.first;
             int w = vol.second;
-            volume[e] += w;
+            volume[e.sorted()] += w;
         }
         return *this;
     }
@@ -98,12 +103,12 @@ struct comm_volume {
         for (const auto& vol : volume) {
             auto& e = vol.first;
             auto w = vol.second;
-            sum_comm_vol[e] += w;
+            sum_comm_vol[e.sorted] += w;
         }
         for (const auto& vol : other.volume) {
             auto& e = vol.first;
             auto w = vol.second;
-            sum_comm_vol[e] += w;
+            sum_comm_vol[e.sorted] += w;
         }
         return sum_comm_vol;
     }

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -1,4 +1,4 @@
-
+#pragma once
 #include <unordered_map>
 
 namespace grid2grid {
@@ -48,6 +48,8 @@ struct weighted_edge_t {
     int w;
 
     weighted_edge_t() = default;
+    weighted_edge_t(int src, int dest, int weight):
+        e{src, dest}, w(weight) {}
     weighted_edge_t(edge_t& e, int weight):
         e(e), w(weight) {}
     weighted_edge_t(weighted_edge_t& we):
@@ -71,6 +73,10 @@ struct weighted_edge_t {
 
     bool operator==(const weighted_edge_t& other) const {
         return e==other.edge() && w == other.weight();
+    }
+
+    bool operator<(const weighted_edge_t& other) const {
+        return w < other.w;
     }
 };
 

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -112,6 +112,16 @@ struct comm_volume {
         }
         return sum_comm_vol;
     }
+
+    int total_volume() {
+        int sum = 0;
+        for (const auto& vol : volume) {
+            auto& e = vol.first;
+            int w = vol.second;
+            sum += w;
+        }
+        return sum;
+    }
 };
 }
 

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -114,14 +114,15 @@ struct comm_volume {
         return sum_comm_vol;
     }
 
-    int total_volume() {
-        int sum = 0;
+    size_t total_volume() {
+        size_t sum = 0;
         for (const auto& vol : volume) {
             auto& e = vol.first;
             int w = vol.second;
             // if not a local communication, count it
             if (e.src != e.dest) {
-                sum += w;
+                assert(w > 0);
+                sum += (size_t) w;
             }
         }
         return sum;

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -94,7 +94,6 @@ struct comm_volume {
             auto& e = vol.first;
             int w = vol.second;
             volume[e.sorted()] += w;
-            // volume[e] += w;
         }
         return *this;
     }
@@ -111,13 +110,12 @@ struct comm_volume {
             auto& e = vol.first;
             auto w = vol.second;
             sum_comm_vol[e.sorted()] += w;
-            // sum_comm_vol[e] += w;
         }
         return sum_comm_vol;
     }
 
-    size_t total_volume() {
-        size_t sum = 0;
+    int total_volume() {
+        int sum = 0;
         for (const auto& vol : volume) {
             auto& e = vol.first;
             int w = vol.second;

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -6,58 +6,85 @@ struct edge_t {
     int src;
     int dest;
 
-    edge_t = default;
+    edge_t() = default;
     edge_t(int src, int dest):
         src(src), dest(dest) {}
-    edge_t(edge_t& e) src(e.src), dest(e.dest) {}
+    // edge_t(edge_t& e): src(e.src), dest(e.dest) {}
 
     bool operator==(const edge_t& other) const {
         return src==other.src && dest==other.dest;
     }
 };
+}
 
+template <class T>
+inline void combine_hash(std::size_t &s, const T &v) {
+    std::hash<T> h;
+    s ^= h(v) + 0x9e3779b9 + (s << 6) + (s >> 2);
+}
+
+// add hash function specialization for these struct-s
+// so that we can use this class as a key of the unordered_map
+namespace std {
+template <>
+struct hash<grid2grid::edge_t> {
+    std::size_t operator()(const grid2grid::edge_t &k) const {
+        using std::hash;
+
+        // Compute individual hash values for first,
+        // second and third and combine them using XOR
+        // and bit shifting:
+        size_t result = 0;
+        combine_hash(result, k.src);
+        combine_hash(result, k.dest);
+        return result;
+    }
+};
+} // namespace std
+
+namespace grid2grid {
 struct weighted_edge_t {
     edge_t e;
     int w;
 
-    weighted_edge_t = default;
+    weighted_edge_t() = default;
     weighted_edge_t(edge_t& e, int weight):
         e(e), w(weight) {}
     weighted_edge_t(weighted_edge_t& we):
-        e(we.edge()), w(we.weight()) {}
+        e(we.e), w(we.w) {}
 
-    int weight() const {
+    const int weight() const {
         return w;
     }
 
-    int src() const {
+    const int src() const {
         return e.src;
     }
 
-    int dest() const {
+    const int dest() const {
         return e.dest;
     }
 
-    edge_t edge() const {
+    const edge_t& edge() const {
         return e;
     }
 
-    bool operator==(const weighted_edge& other) const {
+    bool operator==(const weighted_edge_t& other) const {
         return e==other.edge() && w == other.weight();
     }
 };
 
 struct comm_volume {
-    using volume_t = std::unordered_map<edge, int>;
+    using volume_t = std::unordered_map<edge_t, int>;
     volume_t volume;
 
-    comm_volume = default;
+    comm_volume() = default;
     comm_volume(volume_t&& v):
         volume(std::forward<volume_t>(v)) {}
 
     comm_volume& operator+=(const comm_volume& other) {
         for (const auto& vol : other.volume) {
-            edge e = vol.first;
+            auto& e = vol.first;
             int w = vol.second;
             volume[e] += w;
         }
@@ -67,13 +94,13 @@ struct comm_volume {
     comm_volume operator+(const comm_volume& other) const {
         volume_t sum_comm_vol;
         for (const auto& vol : volume) {
-            edge e = vol.first;
-            int w = vol.second;
+            auto& e = vol.first;
+            auto w = vol.second;
             sum_comm_vol[e] += w;
         }
         for (const auto& vol : other.volume) {
-            edge e = vol.first;
-            int w = vol.second;
+            auto& e = vol.first;
+            auto w = vol.second;
             sum_comm_vol[e] += w;
         }
         return sum_comm_vol;

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -1,0 +1,84 @@
+
+#include <unordered_map>
+
+namespace grid2grid {
+struct edge_t {
+    int src;
+    int dest;
+
+    edge_t = default;
+    edge_t(int src, int dest):
+        src(src), dest(dest) {}
+    edge_t(edge_t& e) src(e.src), dest(e.dest) {}
+
+    bool operator==(const edge_t& other) const {
+        return src==other.src && dest==other.dest;
+    }
+};
+
+struct weighted_edge_t {
+    edge_t e;
+    int w;
+
+    weighted_edge_t = default;
+    weighted_edge_t(edge_t& e, int weight):
+        e(e), w(weight) {}
+    weighted_edge_t(weighted_edge_t& we):
+        e(we.edge()), w(we.weight()) {}
+
+    int weight() const {
+        return w;
+    }
+
+    int src() const {
+        return e.src;
+    }
+
+    int dest() const {
+        return e.dest;
+    }
+
+    edge_t edge() const {
+        return e;
+    }
+
+    bool operator==(const weighted_edge& other) const {
+        return e==other.edge() && w == other.weight();
+    }
+};
+
+struct comm_volume {
+    using volume_t = std::unordered_map<edge, int>;
+    volume_t volume;
+
+    comm_volume = default;
+    comm_volume(volume_t&& v):
+        volume(std::forward<volume_t>(v)) {}
+
+    comm_volume& operator+=(const comm_volume& other) {
+        for (const auto& vol : other.volume) {
+            edge e = vol.first;
+            int w = vol.second;
+            volume[e] += w;
+        }
+        return *this;
+    }
+
+    comm_volume operator+(const comm_volume& other) const {
+        volume_t sum_comm_vol;
+        for (const auto& vol : volume) {
+            edge e = vol.first;
+            int w = vol.second;
+            sum_comm_vol[e] += w;
+        }
+        for (const auto& vol : other.volume) {
+            edge e = vol.first;
+            int w = vol.second;
+            sum_comm_vol[e] += w;
+        }
+        return sum_comm_vol;
+    }
+};
+}
+
+

--- a/src/grid2grid/comm_volume.hpp
+++ b/src/grid2grid/comm_volume.hpp
@@ -50,10 +50,6 @@ struct weighted_edge_t {
     weighted_edge_t() = default;
     weighted_edge_t(int src, int dest, int weight):
         e{src, dest}, w(weight) {}
-    weighted_edge_t(edge_t& e, int weight):
-        e(e), w(weight) {}
-    weighted_edge_t(weighted_edge_t& we):
-        e(we.e), w(we.w) {}
 
     const int weight() const {
         return w;

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -197,6 +197,7 @@ void copy_local_blocks(std::vector<block<T>>& from, std::vector<block<T>>& to) {
         auto& block_src = from[i];
         auto& block_dest = to[i];
         assert(block_src.non_empty());
+        assert(block_dest.non_empty());
         assert(block_src.total_size() == block_dest.total_size());
         // destination block cannot be transposed
         assert(!block_dest.transpose_on_copy);

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -128,8 +128,6 @@ void copy_block_from_buffer(T *src_ptr, block<T> &b) {
 template <typename T>
 void communication_data<T>::copy_to_buffer() {
     // std::cout << "commuication data.copy_to_buffer()" << std::endl;
-
-// #pragma omp parallel for schedule(dynamic, 1)
 #pragma omp parallel for schedule(dynamic, 1)
     for (unsigned i = 0; i < mpi_messages.size(); ++i) {
         const auto &m = mpi_messages[i];

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -125,7 +125,7 @@ void copy_block_from_buffer(T *src_ptr, block<T> &b) {
 template <typename T>
 void communication_data<T>::copy_to_buffer() {
     // std::cout << "commuication data.copy_to_buffer()" << std::endl;
-#pragma omp parallel for schedule(dynamic, 1)
+// #pragma omp parallel for schedule(dynamic, 1)
     for (unsigned i = 0; i < mpi_messages.size(); ++i) {
         const auto &m = mpi_messages[i];
         block<T> b = m.get_block();
@@ -138,7 +138,7 @@ void communication_data<T>::copy_to_buffer() {
 template <typename T>
 void communication_data<T>::copy_to_buffer(int idx) {
     assert(idx >= 0 && idx+1 < package_ticks.size());
-#pragma omp parallel for schedule(dynamic, 1)
+// #pragma omp parallel for schedule(dynamic, 1)
     for (unsigned i = package_ticks[idx]; i < package_ticks[idx+1]; ++i) {
         const auto &m = mpi_messages[i];
         block<T> b = m.get_block();

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -1,5 +1,4 @@
 #include <grid2grid/communication_data.hpp>
-#include <grid2grid/profiler.hpp>
 
 #include <complex>
 #include <omp.h>
@@ -54,7 +53,6 @@ communication_data<T>::communication_data(std::vector<message<T>> &messages,
                                           int rank, int n_ranks)
     : n_ranks(n_ranks)
     , my_rank(rank) {
-    PE(transform_commdata);
     // std::cout << "constructor of communciation data invoked" << std::endl;
     dspls = std::vector<int>(n_ranks);
     counts = std::vector<int>(n_ranks);
@@ -98,7 +96,6 @@ communication_data<T>::communication_data(std::vector<message<T>> &messages,
     }
 
     partition_messages();
-    PL();
 }
 
 template <typename T>
@@ -192,7 +189,6 @@ void copy_block_to_block(block<T>& src, block<T>& dest) {
 template <typename T>
 void copy_local_blocks(std::vector<block<T>>& from, std::vector<block<T>>& to) {
     assert(from.size() == to.size());
-// #pragma omp parallel for schedule(dynamic, 1)
 #pragma omp parallel for schedule(dynamic, 1)
     for (unsigned i = 0u; i < from.size(); ++i) {
         auto& block_src = from[i];

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -2,6 +2,7 @@
 #include <grid2grid/profiler.hpp>
 
 #include <complex>
+#include <omp.h>
 
 namespace grid2grid {
 // *********************
@@ -128,6 +129,7 @@ template <typename T>
 void communication_data<T>::copy_to_buffer() {
     // std::cout << "commuication data.copy_to_buffer()" << std::endl;
 
+// #pragma omp parallel for schedule(dynamic, 1)
 #pragma omp parallel for schedule(dynamic, 1)
     for (unsigned i = 0; i < mpi_messages.size(); ++i) {
         const auto &m = mpi_messages[i];
@@ -192,6 +194,7 @@ void copy_block_to_block(block<T>& src, block<T>& dest) {
 template <typename T>
 void copy_local_blocks(std::vector<block<T>>& from, std::vector<block<T>>& to) {
     assert(from.size() == to.size());
+// #pragma omp parallel for schedule(dynamic, 1)
 #pragma omp parallel for schedule(dynamic, 1)
     for (unsigned i = 0u; i < from.size(); ++i) {
         auto& block_src = from[i];
@@ -229,13 +232,12 @@ template void
 copy_local_blocks(std::vector<block<std::complex<double>>>& from, std::vector<block<std::complex<double>>>& to);
 
 // template instantiation for copy_block_to_block
-template void
-copy_block_to_block(block<double>& src, block<double>& dest);
-template void
-copy_block_to_block(block<float>& src, block<float>& dest);
-template void
-copy_block_to_block(block<std::complex<float>>& src, block<std::complex<float>>& dest);
-template void
-copy_block_to_block(block<std::complex<double>>& src, block<std::complex<double>>& dest);
-
+// template void
+// copy_block_to_block(block<double>& src, block<double>& dest);
+// template void
+// copy_block_to_block(block<float>& src, block<float>& dest);
+// template void
+// copy_block_to_block(block<std::complex<float>>& src, block<std::complex<float>>& dest);
+// template void
+// copy_block_to_block(block<std::complex<double>>& src, block<std::complex<double>>& dest);
 } // namespace grid2grid

--- a/src/grid2grid/communication_data.cpp
+++ b/src/grid2grid/communication_data.cpp
@@ -26,7 +26,7 @@ int message<T>::get_rank() const {
 template <typename T>
 bool message<T>::operator<(const message<T> &other) const {
     return get_rank() < other.get_rank() ||
-           (get_rank() == other.get_rank() && b < other.get_block());
+           (get_rank() == other.get_rank() && b < other.get_block()); 
 }
 
 template <typename T>

--- a/src/grid2grid/communication_data.hpp
+++ b/src/grid2grid/communication_data.hpp
@@ -49,11 +49,18 @@ class communication_data {
 
     communication_data(std::vector<message<T>> &msgs, int my_rank, int n_ranks);
 
+    // copy all mpi_messages to buffer
     void copy_to_buffer();
+    // copy mpi_messages within the idx-th package
+    // a package includes all mpi_messages
+    // to be sent to the same rank
+    void copy_to_buffer(int idx);
 
     // copy all mpi_messages from buffer
     void copy_from_buffer();
-    // copy mpi_messages[idx] from buffer
+    // copy mpi_messages within the idx-th package
+    // a package includes all mpi_messages
+    // received from the same rank
     void copy_from_buffer(int idx);
 
     T *data();

--- a/src/grid2grid/grid2D.cpp
+++ b/src/grid2grid/grid2D.cpp
@@ -111,15 +111,17 @@ void assigned_grid2D::transpose() {
 
 void assigned_grid2D::reorder_ranks(std::vector<int>& reordering) {
     ranks_reordering = reordering;
-    ranks_reordered = true;
 }
 
 int assigned_grid2D::reordered_rank(int rank) const {
     assert(rank < std::max((int) ranks_reordering.size(), n_ranks));
-    if (ranks_reordered)
+    if (ranks_reordered())
         return ranks_reordering[rank];
     else
         return rank;
 }
 
+bool assigned_grid2D::ranks_reordered() const {
+    return ranks_reordering.size() > 0;
+}
 } // namespace grid2grid

--- a/src/grid2grid/grid2D.cpp
+++ b/src/grid2grid/grid2D.cpp
@@ -115,8 +115,8 @@ void assigned_grid2D::reorder_ranks(std::vector<int>& reordering) {
 }
 
 int assigned_grid2D::reordered_rank(int rank) const {
-    assert(rank < std::max(ranks_reordering.size(), n_ranks));
-    if (ranks_reordered) 
+    assert(rank < std::max((int) ranks_reordering.size(), n_ranks));
+    if (ranks_reordered)
         return ranks_reordering[rank];
     else
         return rank;

--- a/src/grid2grid/grid2D.cpp
+++ b/src/grid2grid/grid2D.cpp
@@ -62,7 +62,9 @@ assigned_grid2D::assigned_grid2D(grid2D &&g,
     , n_ranks(n_ranks) {}
 
 // returns the rank owning block (i, j)
-int assigned_grid2D::owner(int i, int j) const { return ranks[i][j]; }
+int assigned_grid2D::owner(int i, int j) const { 
+    return reordered_rank(ranks[i][j]);
+}
 
 // returns a grid
 const grid2D &assigned_grid2D::grid() const { return g; }
@@ -106,4 +108,18 @@ void assigned_grid2D::transpose() {
     g.transpose();
     ranks = transpose(ranks);
 }
+
+void assigned_grid2D::reorder_ranks(std::vector<int>& reordering) {
+    ranks_reordering = reordering;
+    ranks_reordered = true;
+}
+
+int assigned_grid2D::reordered_rank(int rank) const {
+    assert(rank < std::max(ranks_reordering.size(), n_ranks));
+    if (ranks_reordered) 
+        return ranks_reordering[rank];
+    else
+        return rank;
+}
+
 } // namespace grid2grid

--- a/src/grid2grid/grid2D.hpp
+++ b/src/grid2grid/grid2D.hpp
@@ -74,6 +74,10 @@ class assigned_grid2D {
     // if flag='C' => transpose and conjugate
     void transpose();
 
+    void reorder_ranks(std::vector<int>& reordering);
+
+    int reordered_rank(int rank) const;
+
   private:
     friend bool operator==(assigned_grid2D const &,
                            assigned_grid2D const &) noexcept;
@@ -84,6 +88,9 @@ class assigned_grid2D {
     grid2D g;
     std::vector<std::vector<int>> ranks;
     int n_ranks = 0;
+
+    std::vector<int> ranks_reordering;
+    bool ranks_reordered = false;
 };
 
 bool operator==(assigned_grid2D const &, assigned_grid2D const &) noexcept;

--- a/src/grid2grid/grid2D.hpp
+++ b/src/grid2grid/grid2D.hpp
@@ -15,8 +15,9 @@ For each i, the following must hold:
     - 0 <= cols_split[i] < n_cols
 */
 struct grid2D {
-    // matrix dimensions
+    // number of blocks in a row
     int n_rows = 0;
+    // number of columns in a row
     int n_cols = 0;
     // defines how rows are split
     std::vector<int> rows_split;
@@ -78,6 +79,18 @@ class assigned_grid2D {
 
     int reordered_rank(int rank) const;
 
+    bool ranks_reordered() const;
+
+    friend std::ostream &operator<<(std::ostream &os, const assigned_grid2D &other) {
+        for (int i = 0; i < other.grid().n_rows; ++i) {
+            for (int j = 0; j < other.grid().n_cols; ++j) {
+                os << "block (" << i << ", " << j << ") owned by " 
+                   << other.owner(i, j) << std::endl;
+            }
+        }
+        return os;
+    }
+
   private:
     friend bool operator==(assigned_grid2D const &,
                            assigned_grid2D const &) noexcept;
@@ -90,7 +103,6 @@ class assigned_grid2D {
     int n_ranks = 0;
 
     std::vector<int> ranks_reordering;
-    bool ranks_reordered = false;
 };
 
 bool operator==(assigned_grid2D const &, assigned_grid2D const &) noexcept;

--- a/src/grid2grid/grid_cover.hpp
+++ b/src/grid2grid/grid_cover.hpp
@@ -46,6 +46,10 @@ struct grid_cover {
         cols_cover = get_decomp_cover(g1.cols_split, g2.cols_split);
     }
 
+    block_cover decompose_block(const block_coordinates& b) {
+        return {rows_cover[b.row], cols_cover[b.col]};
+    }
+
     template <typename T>
     block_cover decompose_block(const block<T> &b) {
         int row_index = b.coordinates.row;

--- a/src/grid2grid/grid_layout.hpp
+++ b/src/grid2grid/grid_layout.hpp
@@ -24,7 +24,6 @@ class grid_layout {
 
     void reorder_ranks(std::vector<int>& reordering) {
         grid.reorder_ranks(reordering);
-        ranks_reordered_ = true;
     }
 
     int reordered_rank(int rank) const {
@@ -32,12 +31,11 @@ class grid_layout {
     }
 
     bool ranks_reordered() {
-        return ranks_reordered_;
+        return grid.ranks_reordered;
     }
 
     assigned_grid2D grid;
     local_blocks<T> blocks;
-    bool ranks_reordered_ = false;
 };
 
 } // namespace grid2grid

--- a/src/grid2grid/grid_layout.hpp
+++ b/src/grid2grid/grid_layout.hpp
@@ -22,8 +22,22 @@ class grid_layout {
         }
     }
 
+    void reorder_ranks(std::vector<int>& reordering) {
+        grid.reorder_ranks(reordering);
+        ranks_reordered_ = true;
+    }
+
+    int reordered_rank(int rank) const {
+        return grid.reordered_rank(rank);
+    }
+
+    bool ranks_reordered() {
+        return ranks_reordered_;
+    }
+
     assigned_grid2D grid;
     local_blocks<T> blocks;
+    bool ranks_reordered_ = false;
 };
 
 } // namespace grid2grid

--- a/src/grid2grid/grid_layout.hpp
+++ b/src/grid2grid/grid_layout.hpp
@@ -31,7 +31,7 @@ class grid_layout {
     }
 
     bool ranks_reordered() {
-        return grid.ranks_reordered;
+        return grid.ranks_reordered();
     }
 
     assigned_grid2D grid;

--- a/src/grid2grid/interval.cpp
+++ b/src/grid2grid/interval.cpp
@@ -40,6 +40,11 @@ bool interval::operator!=(const interval &other) const {
     return !(*this == other);
 }
 
+bool interval::operator<(const interval &other) const {
+    return start < other.start || 
+           (start == other.start && end < other.end);
+}
+
 /*
 finds intervals from v that overlap with [start, end),
 i.e. finds start_index and end_index

--- a/src/grid2grid/interval.hpp
+++ b/src/grid2grid/interval.hpp
@@ -37,6 +37,7 @@ struct interval {
 
     bool operator==(const interval &other) const;
     bool operator!=(const interval &other) const;
+    bool operator<(const interval &other) const;
 };
 
 std::ostream &operator<<(std::ostream &os, const interval &other);

--- a/src/grid2grid/memory_utils.hpp
+++ b/src/grid2grid/memory_utils.hpp
@@ -47,7 +47,7 @@ void copy2D(const std::pair<size_t, size_t> &block_dim,
         copy(block_size, src_ptr, dest_ptr);
     } else {
         // if strided, copy column-by-column
-        for (unsigned col = 0; col < dim.second; ++col) {
+        for (size_t col = 0; col < dim.second; ++col) {
             copy(dim.first,
                  src_ptr + ld_src * col,
                  dest_ptr + ld_dest * col);

--- a/src/grid2grid/memory_utils.hpp
+++ b/src/grid2grid/memory_utils.hpp
@@ -66,7 +66,7 @@ void copy_and_transpose(const block<T> b, T* dest_ptr, int dest_stride) {
     int n_rows = b.n_cols();
     int n_cols = b.n_rows();
 
-    int block_dim = 32;
+    int block_dim = std::max(8, 128/(int)sizeof(T));
 
     std::vector<T> b_elems(block_dim);
     for (int block_i = 0; block_i < n_rows; block_i += block_dim) {

--- a/src/grid2grid/memory_utils.hpp
+++ b/src/grid2grid/memory_utils.hpp
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <utility>
 #include <omp.h>
+#include <blaze/math/CustomMatrix.h>
 
 namespace grid2grid {
 namespace memory {
@@ -58,7 +59,6 @@ void copy2D(const std::pair<size_t, size_t> &block_dim,
     }
 }
 
-
 // copy from block to MPI send buffer
 template <typename T>
 void copy_and_transpose(const block<T> b, T* dest_ptr, int dest_stride) {
@@ -75,6 +75,19 @@ void copy_and_transpose(const block<T> b, T* dest_ptr, int dest_stride) {
     int n_blocks_col = (n_cols+block_dim-1)/block_dim;
     int n_blocks = n_blocks_row * n_blocks_col;
 
+    using strided_matrix = blaze::CustomMatrix<T, blaze::unaligned, blaze::unpadded, blaze::columnMajor>;
+    strided_matrix mat1(b.data, (unsigned)b.stride, (unsigned)n_cols);
+    strided_matrix mat2(dest_ptr, (unsigned)dest_stride, (unsigned)n_rows);
+
+    auto mat1_sub = submatrix(mat1, 0u, 0u, n_rows, mat1.columns());
+    auto mat2_sub = submatrix(mat2, 0u, 0u, n_cols, mat2.columns());
+
+    if (b.conjugate_on_copy)
+        mat2_sub = blaze::ctrans(mat1_sub);
+    else
+        mat2_sub = blaze::trans(mat1_sub);
+
+    /*
     std::vector<T> b_elems(block_dim);
     for (int block = 0; block < n_blocks; ++block) {
         int block_i = block / n_blocks_col;
@@ -113,6 +126,7 @@ void copy_and_transpose(const block<T> b, T* dest_ptr, int dest_stride) {
             }
         }
     }
+    */
 }
 } // namespace memory
 } // namespace grid2grid

--- a/src/grid2grid/rank_reordering.hpp
+++ b/src/grid2grid/rank_reordering.hpp
@@ -1,0 +1,54 @@
+#pragma once
+#include <grid2grid/comm_volume.hpp>
+#include <unordered_set>
+#include <vector>
+
+namespace grid2grid {
+std::vector<int> optimal_reordering(comm_volume& comm_volume, int n_ranks) {
+    std::unordered_set<int> visited;
+
+    // identity permutation
+    std::vector<int> permutation;
+    permutation.reserve(n_ranks);
+    for (size_t i = 0; i < n_ranks; ++i) {
+        permutation.push_back(i);
+    }
+
+    std::vector<weighted_edge_t> sorted_edges;
+    sorted_edges.reserve(comm_volume.size());
+    for (const auto& el : comm_volume.volume) {
+        auto& e = el.first;
+        int w = el.second;
+        int src = e.src;
+        int dest = e.dest;
+        sorted_edges.push_back(weighted_edge_t(src, dest, w));
+    }
+
+    // sort the edges by weights (decreasing order)
+    std::sort(sorted_edges.rbegin(), sorted_edges.rend());
+
+    for (const auto& edge : sorted_edges) {
+        // edge: src->dest with weight w
+        if (visited.find(edge.src) != visited.end()) {
+            continue;
+        }
+        if (visited.find(edge.dest) != visited.end()) {
+            continue;
+        }
+
+        // map src -> dest
+        // take this edge to perfect matching
+        permutation[edge.src] = edge.dest;
+
+        // no adjecent edge to these vertices
+        // can be taken in the future
+        // to preserve the perfect matching
+        visited.insert(edge.src);
+        visited.insert(edge.dest);
+    }
+
+    return permutation;
+}
+}
+
+

--- a/src/grid2grid/ranks_reordering.hpp
+++ b/src/grid2grid/ranks_reordering.hpp
@@ -39,6 +39,7 @@ std::vector<int> optimal_reordering(comm_volume& comm_volume, int n_ranks) {
         // map src -> dest
         // take this edge to perfect matching
         permutation[edge.src()] = edge.dest();
+        permutation[edge.dest()] = edge.src();
 
         // no adjecent edge to these vertices
         // can be taken in the future

--- a/src/grid2grid/ranks_reordering.hpp
+++ b/src/grid2grid/ranks_reordering.hpp
@@ -15,7 +15,7 @@ std::vector<int> optimal_reordering(comm_volume& comm_volume, int n_ranks) {
     }
 
     std::vector<weighted_edge_t> sorted_edges;
-    sorted_edges.reserve(comm_volume.size());
+    sorted_edges.reserve(comm_volume.volume.size());
     for (const auto& el : comm_volume.volume) {
         auto& e = el.first;
         int w = el.second;
@@ -29,22 +29,22 @@ std::vector<int> optimal_reordering(comm_volume& comm_volume, int n_ranks) {
 
     for (const auto& edge : sorted_edges) {
         // edge: src->dest with weight w
-        if (visited.find(edge.src) != visited.end()) {
+        if (visited.find(edge.src()) != visited.end()) {
             continue;
         }
-        if (visited.find(edge.dest) != visited.end()) {
+        if (visited.find(edge.dest()) != visited.end()) {
             continue;
         }
 
         // map src -> dest
         // take this edge to perfect matching
-        permutation[edge.src] = edge.dest;
+        permutation[edge.src()] = edge.dest();
 
         // no adjecent edge to these vertices
         // can be taken in the future
         // to preserve the perfect matching
-        visited.insert(edge.src);
-        visited.insert(edge.dest);
+        visited.insert(edge.src());
+        visited.insert(edge.dest());
     }
 
     return permutation;

--- a/src/grid2grid/ranks_reordering.hpp
+++ b/src/grid2grid/ranks_reordering.hpp
@@ -6,7 +6,7 @@
 #include <limits>
 
 namespace grid2grid {
-std::vector<int> optimal_reordering(comm_volume comm_volume, int n_ranks) {
+std::vector<int> optimal_reordering(comm_volume& comm_volume, int n_ranks) {
     std::vector<bool> visited(n_ranks, false);
 
     // identity permutation

--- a/src/grid2grid/transform.cpp
+++ b/src/grid2grid/transform.cpp
@@ -115,43 +115,6 @@ void merge_messages(std::vector<message<T>> &messages) {
 }
 
 template <typename T>
-comm_volume communication_volume(grid_layout<T>& initial_layout,
-                                 grid_layout<T>& final_layout) {
-
-    auto g_init = initial_layout.grid;
-    auto g_final = final_layout.grid;
-    grid_cover g_cover(g_init.grid(), g_final.grid());
-
-    int n_blocks_row = g_init.grid().n_rows;
-    int n_blocks_col = g_init.grid().n_cols;
-
-    std::unordered_map<edge_t, int> weights;
-
-    for (int i = 0; i < n_blocks_row; ++i) {
-        for (int j = 0; j < n_blocks_col; ++j) {
-            auto rank_to_comm_vol = rank_to_comm_vol_for_block(
-                g_init, block_coordinates{i, j}, g_cover, g_final);
-            int rank = g_init.owner(i, j);
-
-            for (const auto& comm_vol : rank_to_comm_vol) {
-                int target_rank = comm_vol.first;
-                int weight = comm_vol.second;
-
-                int smaller_rank = std::min(rank, target_rank);
-                int larger_rank = std::max(rank, target_rank);
-
-                edge_t edge_between_ranks =
-                    {smaller_rank, larger_rank};
-
-                weights[edge_between_ranks] += weight;
-            }
-        }
-    }
-
-    return comm_volume(std::move(weights));
-}
-
-template <typename T>
 std::vector<message<T>> decompose_blocks(const grid_layout<T> &init_layout,
                                          const grid_layout<T> &final_layout) {
     PE(transform_decompose);
@@ -179,7 +142,10 @@ communication_data<T> prepare_to_send(const grid_layout<T> &init_layout,
                                       int rank) {
     // in case ranks were reordered to minimize the communication
     // this might not be the identity function
-    rank = init_layout.reordered_rank(rank);
+    // if (rank == 0) {
+    //     std::cout << "prepare to send: changing rank to " << init_layout.reordered_rank(rank) << std::endl;
+    // }
+    // rank = init_layout.reordered_rank(rank);
     std::vector<message<T>> messages =
         decompose_blocks(init_layout, final_layout);
     return communication_data<T>(messages, rank, final_layout.num_ranks());
@@ -191,7 +157,10 @@ communication_data<T> prepare_to_recv(const grid_layout<T> &final_layout,
                                       int rank) {
     // in case ranks were reordered to minimize the communication
     // this might not be the identity function
-    rank = final_layout.reordered_rank(rank);
+    // if (rank == 0) {
+    //     std::cout << "prepare to recv: changing rank to " << final_layout.reordered_rank(rank) << std::endl;
+    // }
+    // rank = final_layout.reordered_rank(rank);
     std::vector<message<T>> messages =
         decompose_blocks(final_layout, init_layout);
     return communication_data<T>(messages, rank, init_layout.num_ranks());
@@ -522,6 +491,39 @@ void exchange_async(communication_data<T>& send_data, communication_data<T>& rec
 // 
 // }
 
+comm_volume communication_volume(assigned_grid2D& g_init,
+                                 assigned_grid2D& g_final) {
+    grid_cover g_cover(g_init.grid(), g_final.grid());
+
+    int n_blocks_row = g_init.grid().n_rows;
+    int n_blocks_col = g_init.grid().n_cols;
+
+    std::unordered_map<edge_t, int> weights;
+
+    for (int i = 0; i < n_blocks_row; ++i) {
+        for (int j = 0; j < n_blocks_col; ++j) {
+            auto rank_to_comm_vol = rank_to_comm_vol_for_block(
+                g_init, block_coordinates{i, j}, g_cover, g_final);
+            int rank = g_init.owner(i, j);
+
+            for (const auto& comm_vol : rank_to_comm_vol) {
+                int target_rank = comm_vol.first;
+                int weight = comm_vol.second;
+
+                int smaller_rank = std::min(rank, target_rank);
+                int larger_rank = std::max(rank, target_rank);
+
+                edge_t edge_between_ranks =
+                    {smaller_rank, larger_rank};
+
+                weights[edge_between_ranks] += weight;
+            }
+        }
+    }
+
+    return comm_volume(std::move(weights));
+}
+
 template <typename T>
 void transform(grid_layout<T> &initial_layout,
                grid_layout<T> &final_layout,
@@ -529,9 +531,11 @@ void transform(grid_layout<T> &initial_layout,
     int rank;
     MPI_Comm_rank(comm, &rank);
 
+    // std::cout << "rank = " << rank << " preparing sending data" << std::endl;
     communication_data<T> send_data =
         prepare_to_send(initial_layout, final_layout, rank);
 
+    // std::cout << "rank = " << rank << " preparing receiving data" << std::endl;
     communication_data<T> recv_data =
         prepare_to_recv(final_layout, initial_layout, rank);
 
@@ -735,20 +739,4 @@ template grid_layout<std::complex<double>>
 get_scalapack_grid(scalapack::data_layout &layout,
                    std::complex<double> *ptr,
                    int rank);
-
-// template instantiation of communication_volume
-template
-comm_volume communication_volume(grid_layout<float>& initial_layout,
-                                 grid_layout<float>& final_layout);
-template
-comm_volume communication_volume(grid_layout<double>& initial_layout,
-                                 grid_layout<double>& final_layout);
-template
-comm_volume communication_volume(
-        grid_layout<std::complex<float>>& initial_layout,
-        grid_layout<std::complex<float>>& final_layout);
-template
-comm_volume communication_volume(
-        grid_layout<std::complex<double>>& initial_layout,
-        grid_layout<std::complex<double>>& final_layout);
 } // namespace grid2grid

--- a/src/grid2grid/transform.hpp
+++ b/src/grid2grid/transform.hpp
@@ -76,11 +76,6 @@ void transform(grid_layout<T> &initial_layout,
                grid_layout<T> &final_layout,
                MPI_Comm comm);
 
-template <typename T>
-comm_volume communication_volume(grid_layout<T>& initial_layout,
-                                 grid_layout<T>& final_layout);
-
-
-
-
+comm_volume communication_volume(assigned_grid2D& initial_grid,
+                                 assigned_grid2D& final_grid);
 } // namespace grid2grid

--- a/src/grid2grid/transform.hpp
+++ b/src/grid2grid/transform.hpp
@@ -8,6 +8,7 @@
 #include <grid2grid/interval.hpp>
 #include <grid2grid/memory_utils.hpp>
 #include <grid2grid/scalapack_layout.hpp>
+#include <grid2grid/comm_volume.hpp>
 
 #include <algorithm>
 #include <assert.h>
@@ -17,7 +18,6 @@
 #include <stdexcept>
 #include <tuple>
 #include <utility>
-#include <comm_volume.hpp>
 
 namespace grid2grid {
 // template <typename T>
@@ -75,6 +75,10 @@ template <typename T>
 void transform(grid_layout<T> &initial_layout,
                grid_layout<T> &final_layout,
                MPI_Comm comm);
+
+template <typename T>
+comm_volume communication_volume(grid_layout<T>& initial_layout,
+                                 grid_layout<T>& final_layout);
 
 
 

--- a/src/grid2grid/transform.hpp
+++ b/src/grid2grid/transform.hpp
@@ -76,6 +76,14 @@ void transform(grid_layout<T> &initial_layout,
                grid_layout<T> &final_layout,
                MPI_Comm comm);
 
+template <typename T>
+using layout_ref = std::reference_wrapper<grid_layout<T>>;
+
+template <typename T>
+void transform(std::vector<layout_ref<T>>& initial_layouts,
+               std::vector<layout_ref<T>>& final_layouts,
+               MPI_Comm comm);
+
 comm_volume communication_volume(assigned_grid2D& initial_grid,
                                  assigned_grid2D& final_grid);
 } // namespace grid2grid

--- a/src/grid2grid/transform.hpp
+++ b/src/grid2grid/transform.hpp
@@ -17,6 +17,7 @@
 #include <stdexcept>
 #include <tuple>
 #include <utility>
+#include <comm_volume.hpp>
 
 namespace grid2grid {
 // template <typename T>
@@ -74,5 +75,8 @@ template <typename T>
 void transform(grid_layout<T> &initial_layout,
                grid_layout<T> &final_layout,
                MPI_Comm comm);
+
+
+
 
 } // namespace grid2grid

--- a/src/grid2grid/transformer.hpp
+++ b/src/grid2grid/transformer.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include <vector>
+#include <cassert>
+#include <mpi.h>
+
+#include <grid2grid/transform.hpp>
+
+namespace grid2grid {
+template <typename T>
+struct transformer {
+    std::vector<grid_layout<T>&> tasks;
+    MPI_Comm comm;
+    int P;
+    int rank;
+    // total communication volume for transformation of layouts
+    comm_volume comm_vol;
+
+    std::vector<int> rank_permutation;
+
+    // constructor
+    schedule() = default;
+
+    // constructor
+    schedule(MPI_Comm comm) : comm(comm) {
+        MPI_Comm_size(comm, &P);
+        MPI_Comm_rank(comm, &rank);
+    }
+
+    void schedule(grid_layout<T>& from_layout, grid_layout<T>& to_layout) {
+        tasks.push_back(from_layout);
+        tasks.push_back(to_layout);
+    }
+
+    void minimize_comm_volume(assigned_grid2D& from_grid, assigned_grid2D& to_grid) {
+        // total communication volume for transformation of layouts
+        comm_vol += communication_volume(from_grid, to_grid);
+    }
+
+    std::vector<int>& optimal_reordering() {
+        if (rank_permutation.size() == 0) {
+            // compute the optimal rank reordering that minimizes the communication volume
+            rank_permutation = grid2grid::optimal_reordering(comm_vol, P);
+        }
+        return rank_permutation;
+    }
+
+    void transform() {
+        assert(rank_permutation.size());
+
+        assert(tasks.size() % 2 == 0);
+        for (int i = 0; i < tasks.size()/2; ++i) {
+            tasks[2*i+1].reorder_ranks(rank_permutation);
+            transform(tasks[2*i], tasks[2*i+1]);
+        }
+        clear();
+    }
+
+    void clear() {
+        tasks.clear();
+        rank_permutation.clear();
+    }
+};
+}

--- a/src/grid2grid/transformer.hpp
+++ b/src/grid2grid/transformer.hpp
@@ -2,62 +2,42 @@
 #include <vector>
 #include <cassert>
 #include <mpi.h>
-
 #include <grid2grid/transform.hpp>
 
 namespace grid2grid {
 template <typename T>
 struct transformer {
-    std::vector<grid_layout<T>&> tasks;
+    std::vector<layout_ref<T>> from;
+    std::vector<layout_ref<T>> to;
     MPI_Comm comm;
     int P;
     int rank;
-    // total communication volume for transformation of layouts
-    comm_volume comm_vol;
-
-    std::vector<int> rank_permutation;
 
     // constructor
-    schedule() = default;
+    transformer() = default;
 
     // constructor
-    schedule(MPI_Comm comm) : comm(comm) {
+    transformer(MPI_Comm comm) : comm(comm) {
         MPI_Comm_size(comm, &P);
         MPI_Comm_rank(comm, &rank);
     }
 
     void schedule(grid_layout<T>& from_layout, grid_layout<T>& to_layout) {
-        tasks.push_back(from_layout);
-        tasks.push_back(to_layout);
-    }
-
-    void minimize_comm_volume(assigned_grid2D& from_grid, assigned_grid2D& to_grid) {
-        // total communication volume for transformation of layouts
-        comm_vol += communication_volume(from_grid, to_grid);
-    }
-
-    std::vector<int>& optimal_reordering() {
-        if (rank_permutation.size() == 0) {
-            // compute the optimal rank reordering that minimizes the communication volume
-            rank_permutation = grid2grid::optimal_reordering(comm_vol, P);
-        }
-        return rank_permutation;
+        from.push_back(from_layout);
+        to.push_back(to_layout);
     }
 
     void transform() {
-        assert(rank_permutation.size());
-
-        assert(tasks.size() % 2 == 0);
-        for (int i = 0; i < tasks.size()/2; ++i) {
-            tasks[2*i+1].reorder_ranks(rank_permutation);
-            transform(tasks[2*i], tasks[2*i+1]);
-        }
+        grid2grid::transform<T>(from, to, comm);
+        // for (unsigned i = 0u; i < from.size(); ++i) {
+        //     grid2grid::transform<T>(from[i], to[i], comm);
+        // }
         clear();
     }
 
     void clear() {
-        tasks.clear();
-        rank_permutation.clear();
+        from.clear();
+        to.clear();
     }
 };
 }


### PR DESCRIPTION
This PR brings the following optimization improvements:
**- transpose on copy:** transposition now more cache-friendly, 3x faster.
**- rank relabelling:** there is a function that finds the optimal rank relabelling that minimizes the communication volume by reducing it to the Maximum Perfect Matching Problem in a bipartite graph (the Linear Assignment Problem) and uses a greedy approximation to compute it.
**- bulk exchange:** transformer has an option to schedule the layout transformations first and then trigger the exchange in only 1 communication round, instead of having one communication round for each matrix separately. 